### PR TITLE
Google API jars should be on the compile classpath

### DIFF
--- a/src/leiningen/droid/compile.clj
+++ b/src/leiningen/droid/compile.clj
@@ -8,7 +8,9 @@
   (:require leiningen.compile leiningen.javac
             [clojure.java.io :as io]
             [leiningen.core.eval :as eval])
-  (:use [leiningen.droid.utils :only [get-sdk-android-jar unique-jars
+  (:use [leiningen.droid.utils :only [get-sdk-android-jar 
+                                      get-sdk-google-api-jars
+                                      unique-jars
                                       ensure-paths sh dev-build?]]
         [leiningen.core
          [main :only [debug info abort]]
@@ -52,8 +54,11 @@
   [f {{:keys [sdk-path target-version]} :android :as project}]
   (let [classpath (f project)
         [jars paths] ((juxt filter remove) #(re-matches #".+\.jar" %) classpath)
-        result (conj (concat (unique-jars jars) paths)
+        result (conj (concat (unique-jars jars) 
+                              paths 
+                              (get-sdk-google-api-jars sdk-path target-version))
                      (get-sdk-android-jar sdk-path target-version)
+                     
                      (str sdk-path "/tools/support/annotations.jar"))]
     result))
 

--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -76,6 +76,18 @@
   [sdk-root version]
   (str (get-sdk-platform-path sdk-root version) "/android.jar"))
 
+(defn get-sdk-google-api-paths
+  "Returns a version-specific path to the Android platform tools."
+  [sdk-root version]
+  (format "%s/add-ons/addon-google_apis-google-%s" sdk-root version))
+
+(defn get-sdk-google-api-jars
+  "Returns a version-specific paths to all SDK jars."
+  [sdk-root version]
+  (map #(.getAbsolutePath %)
+    (file-seq (clojure.java.io/file 
+              (str (get-sdk-google-api-paths sdk-root version) "/libs")))))
+
 (defn process-jar-path
   "Given a jar-file from the Maven repository parses its path and
   returns the information about it."


### PR DESCRIPTION
It's really needed to use Google Maps, for instance. So I've added that.

If it finds google api folder for target platform, it adds jars to the compile classpath.
