### PR TITLE
Change sign-apk to work with JDK 7

### DIFF
--- a/src/leiningen/droid/build.clj
+++ b/src/leiningen/droid/build.clj
@@ -163,6 +163,8 @@
       (create-debug-keystore keystore-path))
     (ensure-paths unaligned-path keystore-path)
     (sh "jarsigner"
+        "-sigalg" "MD5withRSA"
+        "-digestalg" "SHA1"
         "-keystore" keystore-path
         "-storepass" storepass
         "-keypass" keypass


### PR DESCRIPTION
I wasn't able to test this in the lein-droid plugin itself because I'm not sure how to make leiningen use a different plugin jar, but I did verify that adding those arguments to the jarsigner command made the INSTALL_PARSE_FAILED_NO_CERTIFICATES error I was getting from adb go away.
