### PR TITLE
fix to java.io.FileNotFoundException: templates/AndroidManifest.xml

### DIFF
--- a/src/leiningen/droid/new.clj
+++ b/src/leiningen/droid/new.clj
@@ -19,7 +19,11 @@
   (fn [template & [data]]
     (let [path (string/join "/" [name (sanitize template)])]
       (if data
-        (render-text (-> path io/resource slurp-resource) data)
+        (render-text
+         (try (-> path io/resource slurp-resource)
+              (catch ClassCastException _
+                (slurp-resource path)))
+         data)
         (io/input-stream (io/resource path))))))
 
 (defn package-to-path [package-name]


### PR DESCRIPTION
I got an error while running lein droid new as follows:
java.io.FileNotFoundException: templates/AndroidManifest.xml

This commit is the fix to it.
