### PR TITLE
Correctly expand adb path on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml
 .lein-deps-sum
 .lein-failures
 .lein-plugins
+*~


### PR DESCRIPTION
On Windows `lein droid install` fails wirth error `The path xxx/platform-tools/adb doesn't exist. Abort execution.`.

We should use `sdk-binary` to expand the path to adb correctly depending on our
OS.
