### PR TITLE
disabled removal of :private metadata in release build

### DIFF
--- a/src/leiningen/droid/compile.clj
+++ b/src/leiningen/droid/compile.clj
@@ -95,7 +95,7 @@
   (let [nses (namespaces-to-compile project)
         dev-build (dev-build? project)
         compiler-options (if dev-build {} {:elide-meta [:doc :file :line :added
-                                                        :arglists :private]})]
+                                                        :arglists]})]
     (info (format "Build type: %s, dynamic compilation: %s, remote REPL: %s."
                   (if dev-build "debug" "release")
                   (if (or dev-build start-nrepl-server


### PR DESCRIPTION
This is fix for the following scenario: I've defined two identically named private functions, 

``` clojure
(ns namespace1
  ;; ...
  (use [namespace2]))

(defn- log [msg] 
  ;; ...
  )
;; ...
(ns namespace2
  ;; ...
  )

(defn- log [msg]
  ;;...
  )
```

in two different namespaces, namespace1 and namespace2. After stating (use [namespace2]) in the definition of namespace1 and building in release mode application fails as soon as it loads namespace1 with stacktrace stating that log function is already defined in namespace2.

Please note that trying to change use specification to exclude log function,

``` clojure
(ns namespace1
  ;; ...
  (use [namespace2] :exclude (log)))
```

does not seem to help. But after disabling removal of :private metadata in lein-droid's internals this scenario works correctly. 
