### PR TITLE
Allow lein-droid to run in IDEs

### DIFF
--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -270,7 +270,12 @@
   "Reads the password from the console without echoing the
   characters."
   [prompt]
-  (join (.readPassword (System/console) prompt nil)))
+  (if-let [console (System/console)]
+    (join (.readPassword console prompt nil))
+    (do
+      (print prompt)
+      (flush)
+      (read-line))))
 
 (defn append-suffix
   "Appends a suffix to a filename, e.g. transforming `sample.apk` into


### PR DESCRIPTION
This change checks for the existence of System/console, and if it is null, it falls back on read-line. This allows it to run in environments where System/console doesn't exist, such as in the consoles inside IDEs. They typically work by running the code in a backend process and piping it to/from the GUI, so Java doesn't provide a Console object to them. Your password won't be hidden in this case, but at least it's better than getting a NullPointerException =)
