### PR TITLE
add new option :sigalg

### DIFF
--- a/sample/project.clj
+++ b/sample/project.clj
@@ -28,6 +28,7 @@
                                  ;; key you want to sign APKs with.
                                  ;; :keystore-path "/home/user/.android/private.keystore"
                                  ;; :key-alias "mykeyalias"
+                                 ;; :sigalg "MD5withRSA"
 
                                  ;; You can specify these to avoid
                                  ;; entering them for each rebuild,

--- a/src/leiningen/droid/build.clj
+++ b/src/leiningen/droid/build.clj
@@ -232,12 +232,13 @@ files or jar file, e.g. one produced by proguard."
   Either a debug keystore key or a release key is used based on
   whether the build type is the debug one. Creates a debug keystore if
   it is missing."
-  [{{:keys [out-apk-path
+  [{{:keys [out-apk-path sigalg
             keystore-path key-alias keypass storepass]} :android :as project}]
   (info "Signing APK...")
   (let [dev-build (dev-build? project)
         suffix (if dev-build "debug-unaligned" "unaligned")
         unaligned-path (append-suffix out-apk-path suffix)
+        sigalg (or sigalg "MD5withRSA")
         storepass (cond storepass storepass
                         dev-build "android"
                         :else
@@ -251,7 +252,7 @@ files or jar file, e.g. one produced by proguard."
       (create-debug-keystore keystore-path))
     (ensure-paths unaligned-path keystore-path)
     (sh "jarsigner"
-        "-sigalg" "MD5withRSA"
+        "-sigalg" sigalg
         "-digestalg" "SHA1"
         "-keystore" keystore-path
         "-storepass" storepass


### PR DESCRIPTION
`jarsigner` causes error when not matched private key's algorithm (`-keystore`'s key's algorithm) and sign's algorithm (`-sigalg`) on http://developer.android.com/tools/publishing/app-signing.html#signapp .
And, lein-droid use `-sigalg` to `MD5withRSA` now. It requires `RSA` private key.
But, I generated `DSA` private key in past times and used it for past Android apps.
So, I want to change `-sigalg` to `SHA1withDSA` for support `DSA` private key.

I add `:sigalg` new option for it.
How does this look?
