### PR TITLE
May need to uninstall APK before to install APK on Android device

### DIFF
--- a/src/leiningen/droid/deploy.clj
+++ b/src/leiningen/droid/deploy.clj
@@ -57,7 +57,7 @@
         device (get-device-args adb-bin device-args)]
     (ensure-paths apk-path)
     ;; Uninstall old APK first.
-    ;; (sh adb-bin device "uninstall" (get-package-name manifest-path))
+    (sh adb-bin device "uninstall" (get-package-name manifest-path))
     (sh adb-bin device "install" "-r" apk-path)))
 
 (defn run


### PR DESCRIPTION
Hi.

This code was comment-outed, but it is necesally because `adb install` fails when old APK's private key discord from new APK's private key.
It is occur when old APK is debug version and new APK is release version, and vice versa. because debug version was signed by key for debug, but release version was signed by key for release.

Below is this error log.

```
Applying task droid to (install)
Installing APK...
d:path\to\android-sdk\platform-tools\adb.exe devices
List of devices attached
275501710050095 device

d:\path\to\android-sdk\platform-tools\adb.exe -s 275501710050095 install -r d:\path\to\project\target/appname-debug.apk
        pkg: /data/local/tmp/appname-debug.apk

Failure [INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES]

1196 KB/s (4012547 bytes in 3.276s)
```

If not installed old APK, then fail to `adb uninstall`, but it is not do anything but display `Failure`. It seems harmless.
