### PR TITLE
"adb shell am start -n" requires {packageName}/{Activity} format strictly

### DIFF
--- a/src/leiningen/droid/manifest.clj
+++ b/src/leiningen/droid/manifest.clj
@@ -71,9 +71,7 @@
                             up up
                             (xml-> (attr :android:name)))
         pkg-name (first (xml-> manifest (attr :package)))]
-    (if (.startsWith activity-name pkg-name)
-      activity-name
-      (str pkg-name "/" activity-name))))
+    (str pkg-name "/" activity-name)))
 
 (defn write-manifest-with-internet-permission
   "Updates the manifest on disk guaranteed to have the Internet permission."


### PR DESCRIPTION
It cannot use short format.

```
adb shell am start -n com.example.MainActivity => Error: Bad component name: com.example.MainActivity
adb shell am start -n com.example/.MainActivity => run app
adb shell am start -n com.example/com.example.MainActivity => run app
```
