### PR TITLE
remove "--debug-mode" from "aapt package" unless dev-build

### DIFF
--- a/src/leiningen/droid/build.clj
+++ b/src/leiningen/droid/build.clj
@@ -185,6 +185,7 @@ files or jar file, e.g. one produced by proguard."
   (let [aapt-bin (sdk-binary sdk-path :aapt)
         android-jar (get-sdk-android-jar sdk-path target-version)
         dev-build (dev-build? project)
+        debug-mode (if dev-build ["--debug-mode"] [])
         manifest-file (io/file manifest-path)
         backup-file (io/file (str manifest-path ".backup"))
         ;; Only add `assets` directory if it is present.
@@ -193,7 +194,7 @@ files or jar file, e.g. one produced by proguard."
     (when dev-build
       (io/copy manifest-file backup-file)
       (write-manifest-with-internet-permission manifest-path))
-    (sh aapt-bin "package" "--no-crunch" "-f" "--debug-mode" "--auto-add-overlay"
+    (sh aapt-bin "package" "--no-crunch" "-f" debug-mode "--auto-add-overlay"
         "-M" manifest-path
         "-S" out-res-path
         "-S" res-path


### PR DESCRIPTION
`aapt --help` say,

```
   --debug-mode
       inserts android:debuggable="true" in to the application node of the
       manifest, making the application debuggable even on production devices.
```

So do `aapt package` without `--debug-mode` when release.
