### PR TITLE
revert set-profiles to unmerge-profiles and merge-profiles

### DIFF
--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -4,7 +4,7 @@
 ;;
 (ns leiningen.droid
   (:refer-clojure :exclude [compile doall repl])
-  (:use [leiningen.core.project :only [set-profiles]]
+  (:use [leiningen.core.project :only [merge-profiles unmerge-profiles]]
         [leiningen.core.main :only [abort]]
         [leiningen.help :only (subtask-help-for)]
         [leiningen.droid.compile :only (compile clean-compile-dir code-gen)]
@@ -44,7 +44,8 @@
   "Takes a project map and replaces `:dev` profile with `:release` profile."
   [project]
   (-> project
-      (set-profiles [:release] [:dev])
+      (unmerge-profiles [:dev])
+      (merge-profiles [:release])
       android-parameters))
 
 (def ^{:doc "Default set of tasks to create an application release."}


### PR DESCRIPTION
Hi, Alexander.

You changed from `(unmerge-profiles [:dev]) (merge-profiles [:release])` to `(set-profiles [:release] [:dev])` at c8b06e0ff14fa85dd4d65865a1e19cc36256f2a5 .
But it causes to disable to `lein with-profiles ...` function at release time.
Because, `unmerge-profiles` and `merge-profiles` cared `with-profiles` profiles, but `set-profiles` not care `with-profiles` profiles.
(See https://github.com/technomancy/leiningen/blob/master/leiningen-core/src/leiningen/core/project.clj#L612 . `merge-profiles` and `unmerge-profiles` includes `(concat included-profiles profiles)`, but `set-profiles` not includes this code.)

I need to `with-profiles` for to change some environments. Will you be so obliging as to see this problem.
