### PR TITLE
Target Java 6 in template

### DIFF
--- a/res/templates/project.clj
+++ b/res/templates/project.clj
@@ -9,6 +9,7 @@
 
   :source-paths ["src/clojure" "src"]
   :java-source-paths ["src/java" "gen"]
+  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
 
   :dependencies [[org.clojure-android/clojure "1.5.1-jb" :use-resources true]
                  [neko/neko "3.0.0-preview1"]]


### PR DESCRIPTION
This should allow JDK 7 to be used without the various issues cropping up.
