### PR TITLE
Make launch activity in your manifest non-mandatory, add in optional override

### DIFF
--- a/src/leiningen/droid/deploy.clj
+++ b/src/leiningen/droid/deploy.clj
@@ -96,13 +96,13 @@
 
 (defn run
   "Launches the installed APK on the connected device."
-  [{{:keys [sdk-path manifest-path]} :android} & device-args]
-  (info "Launching APK...")
+  [{{:keys [sdk-path manifest-path launch-activity]} :android} & device-args]
   (ensure-paths manifest-path)
-  (let [adb-bin (sdk-binary sdk-path :adb)
-        device (get-device-args adb-bin device-args)]
-    (sh adb-bin device "shell" "am" "start" "-n"
-        (get-launcher-activity manifest-path))))
+  (when-let [activity (or launch-activity (get-launcher-activity manifest-path))]
+    (info "Launching APK...")
+    (let [adb-bin (sdk-binary sdk-path :adb)
+          device (get-device-args adb-bin device-args)]
+      (sh adb-bin device "shell" "am" "start" "-n" activity))))
 
 (defn forward-port
   "Binds a port on the local machine to the port on the device.

--- a/src/leiningen/droid/manifest.clj
+++ b/src/leiningen/droid/manifest.clj
@@ -65,13 +65,13 @@
   manifest that belongs to the _launcher_ category."
   [manifest-path]
   (let [manifest (load-manifest manifest-path)
-        [activity-name] (-> manifest
+        [activity-name] (some-> manifest
                             get-all-launcher-activities
                             first
                             up up
                             (xml-> (attr :android:name)))
         pkg-name (first (xml-> manifest (attr :package)))]
-    (str pkg-name "/" activity-name)))
+    (when activity-name (str pkg-name "/" activity-name))))
 
 (defn write-manifest-with-internet-permission
   "Updates the manifest on disk guaranteed to have the Internet permission."


### PR DESCRIPTION
I am developing an app which I don't want to start an activity from my manifest on run. This makes it so that if you haven't defined such an activity in your manifest, it will simply skip that step rather than crash with an NPE.

I also added :android :launch-activity as an optional override, for example to run a separate
test app which uses your service/sharing intent, etc. or simply a
debugging activity which isn't in your manifest as a launcher.
