### PR TITLE
Improved manifest manipulation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[robert/hooke "1.3.0"]
-                 [org.clojure/data.zip "0.1.1"]]
+                 [org.clojure/data.zip "0.1.1"]
+                 [de.ubercode.clostache/clostache "1.4.0"]]
   :min-lein-version "2.0.0"
   :resource-paths ["res"]
   :eval-in-leiningen true)

--- a/src/leiningen/droid/build.clj
+++ b/src/leiningen/droid/build.clj
@@ -181,7 +181,7 @@ files or jar file, e.g. one produced by proguard."
   and creating a new one with Internet permission appended to it.
   After the packaging the original manifest file is restored."
   [{{:keys [sdk-path target-version manifest-path assets-path res-path
-            out-res-path external-res-paths out-res-pkg-path]} :android
+            out-res-path external-res-paths out-res-pkg-path apk-package-name]} :android
             :as project}]
   (info "Packaging resources...")
   (ensure-paths sdk-path manifest-path res-path)
@@ -197,15 +197,17 @@ files or jar file, e.g. one produced by proguard."
     (when dev-build
       (io/copy manifest-file backup-file)
       (write-manifest-with-internet-permission manifest-path))
-    (sh aapt-bin "package" "--no-crunch" "-f" debug-mode "--auto-add-overlay"
-        "-M" manifest-path
-        "-S" out-res-path
-        "-S" res-path
-        external-resources
-        assets
-        "-I" android-jar
-        "-F" out-res-pkg-path
-        "--generate-dependencies")
+    (sh aapt-bin
+           "package" "--no-crunch" "-f" debug-mode "--auto-add-overlay"
+           "-M" manifest-path
+           "-S" out-res-path
+           "-S" res-path
+           external-resources
+           assets
+           "-I" android-jar
+           "-F" out-res-pkg-path
+           "--generate-dependencies"
+           (if apk-package-name ["--rename-manifest-package" apk-package-name] []))
     (when dev-build
       (io/copy backup-file manifest-file)
       (io/delete-file backup-file))))

--- a/src/leiningen/droid/compile.clj
+++ b/src/leiningen/droid/compile.clj
@@ -7,7 +7,7 @@
             [leiningen.core.eval :as eval])
   (:use [leiningen.droid.utils :only [get-sdk-android-jar sdk-binary
                                       ensure-paths sh dev-build?]]
-        [leiningen.droid.manifest :only [get-package-name]]
+        [leiningen.droid.manifest :only [get-package-name generate-manifest]]
         [leiningen.core
          [main :only [debug info abort]]
          [classpath :only [get-classpath]]]
@@ -28,7 +28,7 @@
                           [k# (symbol (subs (str v#) 2))])
                         *data-readers*)))))
 
-(defn code-gen
+(defn generate-resource-code
   "Generates the R.java file from the resources.
 
   This task is necessary if you define the UI in XML and also to gain
@@ -52,7 +52,14 @@
         external-resources
         "-I" android-jar
         "-J" gen-path
-        "--generate-dependencies")))
+        "--generate-dependencies"))
+  project)
+
+(defn code-gen
+  "Generates R.java and builds a manifest with the appropriate version
+  code and substitutions."
+  [project]
+  (-> project generate-manifest generate-resource-code))
 
 ;; ### Compilation
 


### PR DESCRIPTION
Much more flexible manifest system. Define a :manifest-template xml file which has placeholders in the clostache format, for example {{version-code}}, then specify an :android :manifest map with the appropriate substitutions. This can be used to insert debug permissions, version codes, change app names in different profiles, etc.

Bundled with this I have made the default map insert the {{version-name}} and {{version-code}} substitutions from the semantic leiningen version string. This will work if you stick to standard semantic
versioning (which the new leiningen releases feature does).

This feature is back-compatible. :manifest-file remains as an option, and is the _output_ of the template substitution, so I would recommend by default this is set to target/AndroidManifest.xml if you're using the
new :manifest-template option.

There is a lot of other code which could be simplified in lein-droid using this approach without breaking back-compatibility I think, and even bigger improvements which could be made if this was the default way to do manifest manipulation. This has the nice property that it can be overridden in different profiles and arbitrarily extended without needing to hardcode every situation ahead of time.

I've also included the option to change the apk package namespace (different to the namespace which R references etc), this lets you install multiple versions of your app without them conflicting, which I need to have a release version installed at the same time as actively developing.

Here's a gist with a skeleton manifest and project.clj making use of the new features. Note that when this runs, the versionCode and versionName will be automatically set in the manifest map as per the "1.3.1-SNAPSHOT" set in the project.clj
