### PR TITLE
Added explicit build-tools version handling

### DIFF
--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -48,7 +48,7 @@
                    (->> (.list bt-root-dir)
                         (filter #(.isDirectory (file bt-root-dir %)))
                         sort last))
-        bt-ver (Integer/parseInt (get (re-find #"(\d+)\..*" bt-dir) 1 -1))]
+        bt-ver (Integer/parseInt (get (re-find #"(\d+)\..*" bt-dir) 1 "-1"))]
     ;; if bt-ver is non-negative we have a definite numeric version number
     ;; assume the latest build-tools dir is not empty
     (cond


### PR DESCRIPTION
Parsed either build-tools-version or name of build-tools subfolder to determine version.  Also includes updated tool location for zipalign for v20.  Note, shemefully, I'm unable to build the plugin to test this (lein seems to hang & peg 1 core at max), but the code works at the REPL.
