### PR TITLE
Stop merging/unmerging profiles and parts of profiles randomly

### DIFF
--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="test.leindroid.sample"
-          android:versionCode="1"
-          android:versionName="1.0" >
+          package="{{manifest-package}}"
+          android:versionCode="{{version-code}}"
+          android:versionName="{{version-name}}" >
 
   <uses-sdk android:minSdkVersion="10" />
 
   <application
       android:icon="@drawable/ic_launcher"
-      android:label="@string/app_name">
+      android:label="{{app-name}}">
     <activity android:name=".SplashActivity"
               android:theme="@android:style/Theme.Translucent.NoTitleBar">
       <intent-filter>

--- a/sample/project.clj
+++ b/sample/project.clj
@@ -15,28 +15,61 @@
   ;; don't forget to remove respective dependencies.
   ;; :java-only true
 
+  :aliases {"doall-trial" ["with-profile" "trial-version-dev" "do" ["droid" "build"] ["droid" "apk"] ["droid" "deploy"]]}
+  
   :dependencies [[org.clojure-android/clojure "1.6.0-RC1" :use-resources true]
                  [neko/neko "3.0.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.3"]
-                                  [compliment "0.0.3"]]
-                   :android {:aot :all-with-unused}}
-             :release {:android {;; Specify the path to your private
-                                 ;; keystore and the the alias of the
-                                 ;; key you want to sign APKs with.
-                                 ;; :keystore-path "/home/user/.android/private.keystore"
-                                 ;; :key-alias "mykeyalias"
-                                 ;; :sigalg "MD5withRSA"
+  :profiles {:android-dev [:android-config ; :android-config should be
+                                           ; specified in your
+                                           ; .lein/profiles.clj and
+                                           ; contain machine-specific
+                                           ; options such as
+                                           ; {:android {:sdk-path ""}}
+                           {:dependencies [[org.clojure/tools.nrepl "0.2.3"]
+                                           [compliment "0.0.3"]]
+                            :android {:aot :all-with-unused
 
-                                 ;; You can specify these to avoid
-                                 ;; entering them for each rebuild,
-                                 ;; but generally it's a bad idea.
-                                 ;; :keypass "android"
-                                 ;; :storepass "android"
+                                      ;; The namespace of the app
+                                      ;; package - having a different
+                                      ;; one for dev and release allows
+                                      ;; you to install both at the
+                                      ;; same time
+                                      :apk-package-name "my.sample.app.dev"}}]
+             :android-release [:android-config
+                               {:android { ;; Specify the path to your private
+                                          ;; keystore and the the alias of the
+                                          ;; key you want to sign APKs with.
+                                          ;; :keystore-path "/home/user/.android/private.keystore"
+                                          ;; :key-alias "mykeyalias"
+                                          ;; :sigalg "MD5withRSA"
 
-                                 :ignore-log-priority [:debug :verbose]
-                                 :aot :all}}}
+                                          ;; You can specify these to avoid
+                                          ;; entering them for each rebuild,
+                                          ;; but generally it's a bad idea.
+                                          ;; :keypass "android"
+                                          ;; :storepass "android"
 
-  :android {;; Specify the path to the Android SDK directory either
+                                          :ignore-log-priority [:debug :verbose]
+                                          :aot :all
+
+                                          ;; This tells lein-droid to
+                                          ;; build in release mode,
+                                          ;; disabling debugging and
+                                          ;; signing the resulting
+                                          ;; package
+                                          :build-type :release}}]
+
+             ;; Here's an example of using different profiles
+             :trial-version-dev [:android-config
+                                 :android-dev
+                                 {:android {:apk-package-name "my.sample.app.dev.trial"
+                                            ;And then some options which might be
+                                            ;additional/different source-paths to pull in different
+                                            ;code, or a manifest option which configures some aspect
+                                            ;of your application
+                                            }}]}
+
+  :android { ;; Specify the path to the Android SDK directory either
             ;; here or in your ~/.lein/profiles.clj file.
             ;; :sdk-path "/home/user/path/to/android-sdk/"
 
@@ -88,4 +121,10 @@
             ;; Sequence of namespaces that should not be compiled.
             :aot-exclude-ns ["clojure.parallel" "clojure.core.reducers"]
 
+            ;; This specifies replacements which are inserted into
+            ;; AndroidManifest.xml at build time. See cloustache for
+            ;; more advanced substitution syntax. Version name and
+            ;; code are automatically inserted
+            :manifest {:manifest-package "my.sample.app"
+                       :app-name         "Sample App"}
             })

--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -303,9 +303,10 @@
   (with-process [process (flatten args)]))
 
 (defn dev-build?
-  "Checks if the current Leiningen run contains :dev profile."
+  "Checks the build type of the current project, assuming dev build if
+  not a release build"
   [project]
-  (not (contains? (-> project meta :included-profiles set) :release)))
+  (not= (get-in project [:android :build-type]) :release))
 
 (defn wrong-usage
   "Returns a string with the information about the proper function usage."


### PR DESCRIPTION
simply encourage profiles which don't derive from base or user and have an :android-config in your
profiles for setting the sdk path and any injections or dependencies which
you want to include in all your android projects.

This also allows the :android :build-type :debug or :release option,
rather than examining which profiles were included, this is far more
robust and allows you to have multiple release and debug
profiles. Generally this is more predictable and in line with the way
that leiningen profiles are supposed to be used.

I have left the doall and release tasks for now for back compatibility
and quick-start, but more and more they should be replaced my profile
inheritance and simple aliases in the future.

Doall and release only pull in :android-dev and :android-release respectively, and both pull in :android-config which is expected to be found in your profiles.clj, these should be minimal tweaks to configuration and remove a _lot_ of headaches and potential pitfalls.
