### PR TITLE
Abort if build tools not found

### DIFF
--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -46,7 +46,9 @@
         bt-dir (or build-tools-version
                    (->> (.list bt-root-dir)
                         (filter #(.isDirectory (file bt-root-dir %)))
-                        sort last))
+                        sort last)
+                   (abort "Build tools not found."
+                          "Download them using the Android SDK Manager."))
         bt-ver (Integer/parseInt (get (re-find #"(\d+)\..*" bt-dir) 1 "-1"))]
     ;; if bt-ver is non-negative we have a definite numeric version number
     ;; assume the latest build-tools dir is not empty


### PR DESCRIPTION
Currently, if you have the SDK downloaded but haven't retrieved the build tools, you get a big exception. This provides a more user-friendly error message.
