### PR TITLE
Add Travis CI build for the sample project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: android
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2
+
+before_install:
+  - mkdir ~/bin
+  - wget https://raw.github.com/technomancy/leiningen/stable/bin/lein -P ~/bin/
+  - chmod a+x ~/bin/lein
+  - mkdir ~/.lein
+
+android:
+  components:
+    - build-tools-21.1.1
+    - android-18
+    - extra-android-m2repository
+
+lein: ~/bin/lein
+
+script:
+    - cd sample
+    - DEBUG=1 lein with-profile travis droid build
+    - DEBUG=1 lein with-profile travis droid apk

--- a/README.org
+++ b/README.org
@@ -1,5 +1,7 @@
 * lein-droid
 
+  [[https://travis-ci.org/clojure-android/lein-droid/][https://travis-ci.org/clojure-android/lein-droid.svg?branch=master]]
+
   A Leiningen plugin to simplify Clojure development for Android
   platform. It acts as a build-tool for Clojure/Android projects.
 

--- a/sample/project.clj
+++ b/sample/project.clj
@@ -19,6 +19,16 @@
 
   :profiles {:default [:dev]
 
+             ;; This is a profile for Travis CI build
+             :travis
+             [:android-common :android-user
+              {:dependencies [[org.clojure/tools.nrepl "0.2.10"]]
+               :target-path "target/debug"
+               :android {:aot :all-with-unused
+                         :rename-manifest-package "test.leindroid.sample.debug"
+                         :manifest-options {:app-name "Android-Clojure (debug)"}
+                         :sdk-path "/usr/local/android-sdk/"}}]
+
              :dev
              [:android-common :android-user
               ;; The above profiles can be specified in your profiles.clj and


### PR DESCRIPTION
The build will compile the sample project and create an APK. We
add a new profile in the sample project configuration to define
where the Android SDK is located in the Travis CI system.