### PR TITLE
Incremental Build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-droid/lein-droid "0.4.1"
+(defproject lein-droid/lein-droid "0.4.2-SNAPSHOT"
   :description "Plugin for easy Clojure/Android development and deployment"
   :url "https://github.com/clojure-android/lein-droid"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -61,8 +61,8 @@
      (init-hooks)
      (when (and (nil? project) (not (#{"new" "help" "init"} cmd)))
        (abort "Subtask" cmd "should be run from the project folder."))
-     (ensure-paths (-> project :android :sdk-path))
-     (doto (android-parameters project)
+     (ensure-paths (-> (proj) :android :sdk-path))
+     (doto (android-parameters (proj))
        extract-aar-dependencies
        (execute-subtask cmd args))))
 

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -104,11 +104,10 @@
   "Interactively build the components that are necessary to be built, i.e. build stale
    resources only. Do not build that's not updated since the last time."
   [project]
-  (info "dependencies for crete-dex" ((ib/get-subtask-dependencies project) "crete-dex"))
   (info "Running conditional build")
   (doto project
     (conditional-execute-subtask "compile")
-    (create-dex)))
+    (conditional-execute-subtask "create-dex")))
 
 (defn execute-subtask
   "Executes a subtask defined by `name` on the given project."

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -75,12 +75,14 @@
    which subtasks in code-gen are required to be run."
   [{{:keys [library gen-path]} :android :as project, root :root}]
   (info "Running conditional code generation")
-  (doto project
-    generate-manifest generate-resource-code)
   (let [project-file (get-project-file root (str))
         timestamp-file-name (str gen-path "/timestamps.txt")]
     (when
       (ib/file-modified? project-file (io/file timestamp-file-name))
+      (info "Dependency(project.clj) is modified since last recorded time, regenerating manifests.")
+      (generate-manifest project)
+      (info "Dependency(project.clj) is modified since last recorded time, regenerating R.java code.")
+      (generate-resource-code project)
       (info "Dependency(project.clj) is modified since last recorded time, regenerating BuildConfig.java")
       (generate-build-constants project)
       (spit timestamp-file-name (prn-str {(str project-file) (.lastModified project-file)})))))

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -77,26 +77,14 @@
   (let [dependencies (map #(str root java.io.File/separator %)
                           ((ib/get-subtask-dependencies) subtask))
         timestamp-file-name (str gen-path "/timestamps.txt")]
+    (when (ib/input-modified? timestamp-file-name subtask dependencies)
+      (info "Dependecies are modified since last recorded time. Re-doing" subtask)
       (case subtask
-        "generate-manifest"
-        (do
-          (when (ib/input-modified? timestamp-file-name subtask dependencies)
-            (info "Dependecies are modified since last recorded time. Re-doing" subtask)
-            (generate-manifest project)
-            (ib/record-timestamps timestamp-file-name subtask dependencies)))
-        "generate-resource-code"
-        (do
-          (when (ib/input-modified? timestamp-file-name subtask dependencies)
-            (info "Dependecies are modified since last recorded time. Re-doing" subtask)
-            (generate-resource-code project)
-            (ib/record-timestamps timestamp-file-name subtask dependencies)))
-        "generate-build-constants"
-        (do
-          (when (ib/input-modified? timestamp-file-name subtask dependencies)
-            (info "Dependecies are modified since last recorded time. Re-doing" subtask)
-            (generate-build-constants project)
-            (ib/record-timestamps timestamp-file-name subtask dependencies)))
-        (println "Unregonized subtask: " subtask))))
+        "generate-manifest" (generate-manifest project)
+        "generate-resource-code" (generate-resource-code project)
+        "generate-build-constants" (generate-build-constants project)
+        (println "Unregonized subtask: " subtask))
+      (ib/record-timestamps timestamp-file-name subtask dependencies))))
 
 (defn conditional-code-gen
   "Initiate the conditional execution of metatask code-gen. We identify

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -47,6 +47,7 @@
 (defn doall
   "Metatask. Performs all Android tasks from compilation to deployment."
   [{{:keys [library]} :android :as project} & device-args]
+  (ib/ensure-sdk project)
   (let [build-steps (if library ["build"] ["code-gen" "build" "apk" "deploy"])]
     (doseq [task build-steps]
       (execute-subtask project task device-args))))

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -72,11 +72,11 @@
 
 (defn conditional-execute-subtask
   "Conditionally execute the specified subtask."
-  [{{:keys [gen-path]} :android :as project, root :root} subtask]
+  [{:as project, :keys [root target-path]} subtask]
   (ensure-paths root)
   (let [dependencies (map #(str root java.io.File/separator %)
                           ((ib/get-subtask-dependencies) subtask))
-        timestamp-file-name (str gen-path "/timestamps.txt")]
+        timestamp-file-name (str target-path "/timestamps.txt")]
     (when (ib/input-modified? timestamp-file-name subtask dependencies)
       (info "Dependecies are modified since last recorded time. Re-doing" subtask)
       (case subtask

--- a/src/leiningen/droid.clj
+++ b/src/leiningen/droid.clj
@@ -42,7 +42,7 @@
 (defn doall
   "Metatask. Performs all Android tasks from compilation to deployment."
   [{{:keys [library]} :android :as project} & device-args]
-  (let [build-steps (if library ["build"] ["build" "apk" "deploy"])]
+  (let [build-steps (if library ["build"] ["code-gen" "build" "apk" "deploy"])]
     (doseq [task build-steps]
       (execute-subtask project task device-args))))
 
@@ -75,7 +75,6 @@
             (abort (wrong-usage "lein droid new" #'new))
             (apply new args))
     "init" (init (.getAbsolutePath (clojure.java.io/file ".")))
-    "code-gen" (code-gen project)
     "compile" (compile project)
     "create-dex" (create-dex project)
     "crunch-resources" (crunch-resources project)
@@ -94,6 +93,7 @@
     "local-test" (apply local-test project args)
 
     ;; Meta tasks
+    "code-gen" (code-gen project)
     "build" (build project)
     "apk" (apk project)
     "deploy" (apply deploy project args)

--- a/src/leiningen/droid/build.clj
+++ b/src/leiningen/droid/build.clj
@@ -134,7 +134,7 @@
   "Metatask. Compiles the project and creates DEX."
   [{{:keys [library]} :android :as project}]
   (doto project
-    code-gen compile create-dex))
+    compile create-dex))
 
 (defn jar
   "Metatask. Packages compiled Java files and Clojure sources into JAR.

--- a/src/leiningen/droid/code_gen.clj
+++ b/src/leiningen/droid/code_gen.clj
@@ -36,23 +36,9 @@
             :type (java-type v)}))
        constants))
 
-(defn project-modified?
-  "Check if the project.clj was modified since the last time recorded. Return false
-  iff recorded timestamp is same as the one that's read recently."
-  [project-file timestamp-file]
-  (if (not (.exists timestamp-file))
-    true
-    (let [project-file-time (.lastModified project-file)
-          project-file-name (str project-file)
-          timestamps (edn/read-string (slurp timestamp-file))]
-      (if (and (contains? timestamps project-file-name) 
-        (== (timestamps project-file-name) project-file-time))
-        false
-        true))))
-
 (defn generate-build-constants
   [{{:keys [manifest-path gen-path build-config rename-manifest-package]}
-    :android, version :version :as project, root :root}]
+    :android, version :version :as project}]
   (ensure-paths manifest-path)
   (let [res (io/resource "templates/BuildConfig.java")
         package-name (get-package-name manifest-path)
@@ -61,19 +47,13 @@
         template-constants (-> (merge {"VERSION_NAME"   version
                                        "APPLICATION_ID" application-id}
                                       build-config)
-                               map-constants)
-        project-file (get-project-file root (str))
-        timestamp-file-name (str gen-path "/timestamps.txt")
-        project-file-time (.lastModified project-file)]
-    (when (project-modified? project-file (io/file timestamp-file-name))
-      (info "project.clj is modified since last recorded time, regenerating BuildConfig.java")
-      (ensure-paths gen-package-path)
-      (->> {:debug        (dev-build? project)
-            :package-name package-name
-            :constants    template-constants}
-           (clostache/render (slurp-resource res))
-           (spit (io/file gen-package-path "BuildConfig.java")))
-      (spit timestamp-file-name (prn-str {(str project-file) (.lastModified project-file)})))))
+                               map-constants)]
+    (ensure-paths gen-package-path)
+    (->> {:debug        (dev-build? project)
+          :package-name package-name
+          :constants    template-constants}
+         (clostache/render (slurp-resource res))
+         (spit (io/file gen-package-path "BuildConfig.java")))))
 
 ;; ### R.java generation
 

--- a/src/leiningen/droid/code_gen.clj
+++ b/src/leiningen/droid/code_gen.clj
@@ -136,7 +136,7 @@
       (generate-r-files project))))
 
 (defn code-gen
-  "Generates R.java and builds a manifest with the appropriate version
+  "Metatask. Generates R.java and builds a manifest with the appropriate version
   code and substitutions."
   [{{:keys [library]} :android :as project}]
   (doto project

--- a/src/leiningen/droid/compile.clj
+++ b/src/leiningen/droid/compile.clj
@@ -139,7 +139,7 @@
 
 (defn compile
   "Compiles both Java and Clojure source files."
-  [{{:keys [sdk-path gen-path lean-compile]} :android,
+  [{{:keys [sdk-path]} :android,
     java-only :java-only :as project}]
   (ensure-paths sdk-path)
   (let [project (-> project

--- a/src/leiningen/droid/inc_build.clj
+++ b/src/leiningen/droid/inc_build.clj
@@ -4,8 +4,191 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.edn :as edn]
+            [clj-http.client :as http]
+            [clojure.xml :as xml]
             [leiningen.core.main :refer [info debug]])
-  (:use [leiningen.droid.utils :only [append-suffix]]))
+  (:use [leiningen.droid.utils :only [platform append-suffix absolutize]]))
+
+(defn- download-zip
+  "Connect to the internet and download given application/zip file. Once the file is downloaded
+  return the file (io/file) from the local."
+  [path url]
+  (let [head (http/head url)
+        headers (:headers head)
+        type-of-contents (:Content-type headers)]
+    (debug "Content type is" type-of-contents)
+    (when (= type-of-contents "application/zip")
+      (let [relative-file-name (subs url (inc (.lastIndexOf url "/")))
+            dir (absolutize path "temp")
+            _ (.mkdir (java.io.File. dir))
+            file-name (absolutize dir relative-file-name)]
+        (info "Downloading" file-name "from" url)
+        (io/copy (:body (http/get url {:as :stream}))
+                 (java.io.File. file-name))
+        file-name))))
+
+(defn- download-xml
+  "Connect to the internet and download a given xml file. Return the clojure map that's parsed
+  from the given xml."
+  [url]
+  (let [head (http/head url)
+        headers (:headers head)
+        type-of-contents (:Content-type headers)]
+    (debug "Content type is" type-of-contents)
+    (info "Downloading repository at" url)
+    (when (= type-of-contents "application/xml")
+      (-> (http/get url)
+          :body
+          .getBytes
+          java.io.ByteArrayInputStream.
+          xml/parse))))
+
+(defn- repository
+  "Links to the repository metadata for the components."
+  []
+  {:sdk:platform "https://dl.google.com/android/repository/repository-10.xml"
+   :sdk:platform-tool "https://dl.google.com/android/repository/repository-10.xml"
+   :sdk:build-tool "https://dl.google.com/android/repository/repository-10.xml"
+   :sdk:tool "https://dl.google.com/android/repository/repository-10.xml"
+   :sdk:sample "https://dl.google.com/android/repository/repository-10.xml"
+   :sdk:source "https://dl.google.com/android/repository/repository-10.xml"
+   :google-apis "https://dl.google.com/android/repository/addon.xml"
+   :android-support-lib "https://dl.google.com/android/repository/addon-6.xml"
+   :glass-dev-kit "https://dl-ssl.google.com/glass/gdk/addon.xml"
+   :intel-emulator "https://dl.google.com/android/repository/extras/intel/addon.xml"
+   :systel-images "https://dl.google.com/android/repository/sys-img/android/sys-img.xml"
+   :android-wear-sysimages "https://dl.google.com/android/repository/sys-img/android-wear/sys-img.xml"
+   :android-tv-sysimages "https://dl.google.com/android/repository/sys-img/android-tv/sys-img.xml"
+   :google-apis-sysimages "https://dl.google.com/android/repository/sys-img/google_apis/sys-img.xml"})
+
+#_(defn- sdk-tags
+  "Static reference to the nested tags for a given sdk in the .xml file. The sequence of the tags in the value
+  vector is the sequence of nesting found in the actual xml url for the given tag. The comparator is used to
+  compare different versions and identify the latest version. :path-to-url is the nesting of the tags to real
+  url."
+  []
+  {:sdk:platform {:comparator sdk:api-level :path-to-url [sdk:archives sdk:archive sdk:url]}
+   })
+
+(defn- absolutize-url
+  "If the given url is not absolute then, return the absolute url by appending url to the base-url. If
+  url is absolute (i.e. it starts with http:// or https://) then return the url without any modification.
+  Move this function to utils."
+  [base-url url]
+  (if (or (.startsWith url "http://") (.startsWith url "https://"))
+    url
+    (str (subs base-url 0 (inc (.lastIndexOf base-url "/"))) url)))
+
+(defn- fetch-content-for-nested-keyword
+  "Walk down the hierarchy of one child, in order to collect given tag."
+  [tag-keyword child]
+  #_(info "fetch-content-for-nested-keyword: Keyword is" tag-keyword "child node is:" child)
+  (let [content (:content child)
+        sdk-api-level-child (filter #(= (:tag %) tag-keyword) content)
+        api-level (first (:content (first sdk-api-level-child)))]
+    (read-string api-level)))
+
+(defn- extract-platform-dependent-zip
+  [archives platform]
+  "It goes deep and retrieves file names from archives vector. We need to modify this to use :sdk:host-os tag
+  instead of .contains comparison."
+  (debug "extract-platform-dependent-zip: Archives are" (type platform) archives)
+  (let [files-names (map (partial fetch-content-for-nested-keyword :sdk:url) archives)
+        file (filter #(.contains (str %) platform) files-names)]
+    (debug "extract-platform-dependent-zip: Files are" files-names)
+    file))
+
+(defn- extract-platform-url
+  "Given the xml map of the repository determine the download url for the :sdk-platform. This will return the
+  latest url. It will give the absolute URL of the resource. For now it only works with :sdk:platform tags in
+  xml. It should be generic enough to extract any leaf nodes."
+  [xml base-url]
+  (let [content-body (:content xml)
+        sdk-platforms (filter #(= (:tag %) :sdk:platform) content-body)
+        api-levels (map (partial fetch-content-for-nested-keyword :sdk:api-level) sdk-platforms)
+        max-api (apply max api-levels)
+        max-api-index (.indexOf api-levels max-api)
+        sdk-platform-content (:content (get (vec sdk-platforms) max-api-index))
+        archives-content (:content (first (filter #(= (:tag %) :sdk:archives) sdk-platform-content)))
+        platform (platform)
+        file-name (if (< 1 (count archives-content))
+                    (extract-platform-dependent-zip archives-content platform)
+                    (:content (first (filter #(= (:tag %) :sdk:url) (:content (first archives-content))))))]
+    (debug "extract-platform-url: API levels are" api-levels)
+    (debug "extract-platform-url: SDK platform content is" sdk-platform-content)
+    (debug "extract-platform-url: Archives content is" archives-content)
+    (info "extract-platform-url: File to download" (first file-name))
+    (absolutize-url base-url (str (first file-name)))))
+
+(defn- filter-ith-max
+  "From the given nested (only two levels), matrix of numbers filter only the rows that are max at i-th column."
+  [i matrix]
+  (let [ith-max (apply max (map #(get % i) matrix))]
+    (filter #(= ith-max (get % i)) matrix)))
+
+(defn- fetch-revision
+  "From the given vector extract tags with given keyword tag."
+  [tag child-vector]
+  (first (filter #(= (:tag %) tag) child-vector)))
+
+(defn- extract-platform-tool-url
+  "Given the xml map of the repository determine the download url for the :sdk-platform-tool. This will return the
+  latest url. It will give the absolute URL of the resource."
+  [xml base-url]
+  (let [content-body (:content xml)
+        sdk-platform-tools (filter #(= (:tag %) :sdk:platform-tool) content-body)
+        sdk-platform-tools-content (map #(:content %) sdk-platform-tools)
+        sdk-revisions (map (partial fetch-revision :sdk:revision) sdk-platform-tools-content)
+        major-api-levels (map (partial fetch-content-for-nested-keyword :sdk:major) sdk-revisions)
+        minor-api-levels (map (partial fetch-content-for-nested-keyword :sdk:minor) sdk-revisions)
+        micro-api-levels (map (partial fetch-content-for-nested-keyword :sdk:micro) sdk-revisions)
+        revisions (map vector major-api-levels minor-api-levels micro-api-levels)
+        max-revision (first (filter-ith-max 2 (filter-ith-max 1 (filter-ith-max 0 revisions))))
+        required-platform-tool-index (first (keep-indexed #(if (and
+                                                                (and
+                                                                 (= (get max-revision 0) (get %2 0))
+                                                                 (= (get max-revision 1) (get %2 1)))
+                                                                (= (get max-revision 2) (get %2 2)))
+                                                             %1) revisions))
+        required-platform-tool-content (:content (nth sdk-platform-tools required-platform-tool-index))
+        archives-content (:content (fetch-revision :sdk:archives required-platform-tool-content))
+        platform (platform)
+        file-name (if (< 1 (count archives-content))
+                    (extract-platform-dependent-zip archives-content platform)
+                    (:content (first (filter #(= (:tag %) :sdk:url) (:content (first archives-content))))))]
+    (debug "extract-platform-tool-url: SDK revisions" sdk-revisions)
+    (debug "extract-platform-tool-url: Major API levels are" major-api-levels)
+    (debug "extract-platform-tool-url: Minor API levels are" minor-api-levels)
+    (debug "extract-platform-tool-url: Micro API levels are" micro-api-levels)
+    (debug "extract-platform-tool-url: Revisions" revisions)
+    (debug "extract-platform-tool-url: Max revisions" max-revision)
+    (debug "extract-platform-tool-url: Platform tools" sdk-platform-tools)
+    (debug "extract-platform-tool-url: Max required platform tool" required-platform-tool-content)
+    (debug "extract-platform-tool-url: Required platform tool index" required-platform-tool-index)
+    (debug "extract-platform-tool-url: Archives content" archives-content)
+    (info "extract-platform-tool-url: File to download" (first file-name))
+    (absolutize-url base-url (str (first file-name)))))
+
+(defn- get-latest-download-url
+  "Traverse the given xml map for the latest download url of the given sdk. This function for now only
+  returns the latest download urls. It should be flexible enough later to be able to download specific versions
+  of the sdk."
+  [xml sdk base-url]
+  (case sdk
+    :sdk:platform (extract-platform-url xml base-url)
+    :sdk:platform-tool (extract-platform-tool-url xml base-url)
+    "sdk not found."))
+
+(defn ensure-sdk
+  "Ensure if required libraries in the sdk are present or not. If not present
+  then this function will download the sdk automatically from the Android official
+  site and unzip the sdk in temp directory in :sdk-path."
+  [sdk-path]
+  (let [url "https://dl.google.com/android/repository/repository-10.xml"
+        platform-download-url (get-latest-download-url (download-xml url) :sdk:platform url)
+        platform-tool-download-url (get-latest-download-url (download-xml url) :sdk:platform-tool url)]
+    (info "Download url for platform is" platform-download-url)
+    (info "Download url for platform-tool" platform-tool-download-url)))
 
 (defn get-subtask-dependencies
   "Get the file dependencies for subtasks. This is a static class returning a map

--- a/src/leiningen/droid/inc_build.clj
+++ b/src/leiningen/droid/inc_build.clj
@@ -16,7 +16,7 @@
    "generate-resource-code" ["res", "target/debug/AndroidManifest.xml"]
    "generate-build-constants" ["project.clj"]
    "compile" (distinct (project :source-paths))
-   "create-dex" []})
+   "create-dex" ["target/debug/classes"]})
 
 (defn- walk
   "Walk the given directory searching for files. For now we search all the files

--- a/src/leiningen/droid/inc_build.clj
+++ b/src/leiningen/droid/inc_build.clj
@@ -10,25 +10,55 @@
   "Check if input file is modified, since the last time
    recorded. Return false iff recorded timestamp is same as the one
    that's read recently."
-  [input-file timestamp-file]
+  [timestamp-file subtask input-file]
   (if (not (.exists timestamp-file))
     true
     (let [input-file-time (.lastModified input-file)
           input-file-name (str input-file)
-          timestamps (edn/read-string (slurp timestamp-file))]
-      (if (and (contains? timestamps input-file-name)
-        (== (timestamps input-file-name) input-file-time))
+          timestamps (edn/read-string (slurp timestamp-file))
+          recorded-time (get-in timestamps [subtask input-file-name])]
+      (if (and recorded-time (== recorded-time input-file-time))
         false
         true))))
+
+(defn- partial-file-modified?
+  "Partial file-modified? function which takes the timestamp-file."
+  [timestamp-file subtask]
+  (partial file-modified? timestamp-file subtask))
 
 (defn input-modified?
   "Check if some of the given input files are modified. Return true if
    at least one file has been modified."
-  [input-files]
-  (some file-modified? input-files))
+  [timestamp-file-name subtask input-file-names]
+  (let [input-files (map io/file input-file-names)
+        timestamp-file (io/file timestamp-file-name)]
+    (some (partial-file-modified? timestamp-file subtask) input-files)))
 
-(defn generate-build-constants-deps
-  "Get the file dependencies for code-gen/generate-build-constants subtask."
+(defn get-subtask-dependencies
+  "Get the file dependencies for subtasks. This is a static class returning a map
+   of subtask names and corresponding file/directory dependency in a vector. The
+   key name has to be the exact subtask name. The dependency file/directory
+   names are relative to the project (aka project root directory)."
   []
-  (println (input-modified?))
-  ["project.clj"])
+  {"generate-manifest" ["/project.clj"]
+   "generate-resource-code" ["/res", "/target/debug/AndroidManifest.xml"]
+   "generate-build-constants" ["/project.clj"]})
+
+(defn- write-timestamp
+  "First read the current timestamp (for files for subtasks) if exists and update
+   the timestamps in."
+  [timestamp-file-name subtask path]
+  (let [timestamp-file (io/file timestamp-file-name)]
+    (if (not (.exists timestamp-file))
+      (spit timestamp-file-name (prn-str {(str subtask) {(str path) (.lastModified path)}}))
+      (let [timestamps (edn/read-string (slurp timestamp-file))
+            updated-timestamps (update-in timestamps [subtask] assoc (str path) (.lastModified path))]
+        (spit timestamp-file-name (prn-str updated-timestamps))))))
+
+(defn record-timestamps
+  "After execution of each subtask, record the timestamps of the files/directories,
+  that found modified."
+  [timestamp-file-name subtask path-names]
+  (let [paths (map io/file path-names)]
+    (info "Recording timestamps for" subtask paths)
+    (doall (map (partial write-timestamp timestamp-file-name subtask) paths))))

--- a/src/leiningen/droid/inc_build.clj
+++ b/src/leiningen/droid/inc_build.clj
@@ -4,7 +4,19 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.edn :as edn]
-            [leiningen.core.main :refer [info]]))
+            [leiningen.core.main :refer [info debug]]))
+
+(defn get-subtask-dependencies
+  "Get the file dependencies for subtasks. This is a static class returning a map
+   of subtask names and corresponding file/directory dependency in a vector. The
+   key name has to be the exact subtask name. The dependency paths are relative
+   (to the project)."
+  [project]
+  {"generate-manifest" ["project.clj"]
+   "generate-resource-code" ["res", "target/debug/AndroidManifest.xml"]
+   "generate-build-constants" ["project.clj"]
+   "compile" (distinct (project :source-paths))
+   "create-dex" []})
 
 (defn- walk
   "Walk the given directory searching for files. For now we search all the files
@@ -49,16 +61,6 @@
         timestamp-file (io/file timestamp-file-name)]
     (some (partial-file-modified? timestamp-file subtask) input-paths)))
 
-(defn get-subtask-dependencies
-  "Get the file dependencies for subtasks. This is a static class returning a map
-   of subtask names and corresponding file/directory dependency in a vector. The
-   key name has to be the exact subtask name. The dependency file/directory
-   names are relative to the project (aka project root directory)."
-  []
-  {"generate-manifest" ["/project.clj"]
-   "generate-resource-code" ["/res", "/target/debug/AndroidManifest.xml"]
-   "generate-build-constants" ["/project.clj"]})
-
 (defn- write-timestamp
   "First read the current timestamp (for files for subtasks) if exists and update
    the timestamps in."
@@ -67,6 +69,7 @@
         path-timestamp (if (.isDirectory path)
                          (latest-timestamp-in-directory path)
                          (.lastModified path))]
+    (debug "Path is" path "timestamp is" path-timestamp)
     (if (not (.exists timestamp-file))
       (spit timestamp-file-name (prn-str {(str subtask) {(str path) path-timestamp}}))
       (let [timestamps (edn/read-string (slurp timestamp-file))
@@ -79,5 +82,5 @@
    modified file. It recursively traverses directory structure to get the recent timestamp."
   [timestamp-file-name subtask path-names]
   (let [paths (map io/file path-names)]
-    (info "Recording timestamps for" subtask paths)
+    (debug "Recording timestamps for" subtask paths)
     (doall (map (partial write-timestamp timestamp-file-name subtask) paths))))

--- a/src/leiningen/droid/inc_build.clj
+++ b/src/leiningen/droid/inc_build.clj
@@ -1,0 +1,34 @@
+(ns leiningen.droid.inc-build
+  "Subtasks related to build process as a whole. Decides what to run and
+   what not to. It stores the subtasks and files dependencies as function."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.edn :as edn]
+            [leiningen.core.main :refer [info]]))
+
+(defn file-modified?
+  "Check if input file is modified, since the last time
+   recorded. Return false iff recorded timestamp is same as the one
+   that's read recently."
+  [input-file timestamp-file]
+  (if (not (.exists timestamp-file))
+    true
+    (let [input-file-time (.lastModified input-file)
+          input-file-name (str input-file)
+          timestamps (edn/read-string (slurp timestamp-file))]
+      (if (and (contains? timestamps input-file-name)
+        (== (timestamps input-file-name) input-file-time))
+        false
+        true))))
+
+(defn input-modified?
+  "Check if some of the given input files are modified. Return true if
+   at least one file has been modified."
+  [input-files]
+  (some file-modified? input-files))
+
+(defn generate-build-constants-deps
+  "Get the file dependencies for code-gen/generate-build-constants subtask."
+  []
+  (println (input-modified?))
+  ["project.clj"])

--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -2,7 +2,8 @@
 ;;
 (ns leiningen.droid.utils
   (:require [leiningen.core.project :as pr]
-            [robert.hooke :refer [with-hooks-disabled]])
+            [robert.hooke :refer [with-hooks-disabled]]
+            [clojure.java.shell :as shell])
   (:use [clojure.java.io :only (file reader)]
         [leiningen.core.main :only (info debug abort *debug*)]
         [leiningen.core.classpath :only [resolve-dependencies]]
@@ -30,10 +31,24 @@
                  (and (string? ~p) (not (.exists (file ~p)))))
                 (abort "The path" ~p "doesn't exist. Abort execution.")))))
 
+(defn mac?
+  "Returns true if the machine is Darwin machine."
+  []
+  (= (:out (shell/sh "uname")) "Darwin\n"))
+
 (defn windows?
   "Returns true if we are running on Microsoft Windows"
   []
   (= java.io.File/separator "\\"))
+
+(defn platform
+  "Return the platform program running on."
+  []
+  (if (windows?)
+    "windows"
+    (if (mac?)
+      "macosx"
+      "linux")))
 
 (defn get-sdk-build-tools-path
   "Returns a path to the correct Android Build Tools directory."

--- a/src/leiningen/droid/utils.clj
+++ b/src/leiningen/droid/utils.clj
@@ -169,7 +169,7 @@
 
 ;; ### General utilities
 
-(defn proj [] (read-project "sample/project.clj"))
+(defn proj [] (read-project "../test-lein-droid/project.clj"))
 
 (defn sdk-version-number
   "If version keyword is passed (for example, `:ics` or `:jelly-bean`), resolves


### PR DESCRIPTION
Adding a check for code-gen phase. If the project.clj is modified since the last time or modification time was never recorded last time (i.e. timestamp file doesn't exist or timestamp was not present in the timestamp file), then only allow regeneration of BuildConfig.java. Else don't waste resources only generating.