### PR TITLE
Fix for Leiningen 2.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                  [org.clojure/data.zip "0.1.1"]
                  [net.lingala.zip4j/zip4j "1.3.2"]
                  [com.android.tools.build/manifest-merger "24.2.3"]
-                 [de.ubercode.clostache/clostache "1.4.0"]]
+                 [de.ubercode.clostache/clostache "1.4.0"]
+                 [reply "0.3.7"]]
   :resource-paths ["res"]
   :eval-in-leiningen true)

--- a/src/leiningen/droid/classpath.clj
+++ b/src/leiningen/droid/classpath.clj
@@ -6,7 +6,7 @@
                                            get-sdk-annotations-jar
                                            leiningen-2-p-7-or-later?]]
             [robert.hooke :refer [add-hook]])
-  (:import org.sonatype.aether.util.version.GenericVersionScheme))
+  (:import org.eclipse.aether.util.version.GenericVersionScheme))
 
 ;; Since `dx` and `ApkBuilder` utilities fail when they are feeded
 ;; repeated jar-files, we need to make sure that JAR dependencies list


### PR DESCRIPTION
Fix 2 issues for latest Leiningen (Leiningen 2.8.1 on Java 1.8.0_152 Java HotSpot(TM) 64-Bit Server VM).

java.lang.ClassNotFoundException: org.sonatype.aether.util.version.GenericVersionScheme
--
Error: `clojure.lang.Compiler$CompilerException: java.lang.ClassNotFoundException: org.sonatype.aether.util.version.GenericVersionScheme, compiling:(leiningen/droid/classpath.clj:1:1)`

Leiningen switches org.sonatype.aether to org.apache.maven.resolver.

Upgrading to org.eclipse.aether  https://github.com/cemerick/pomegranate/commit/b71ad6f0e3e88003c1ee28458af1f94bd319f6a6
Bump to Maven 3.5.0 and replace aether with maven-resolver. https://github.com/cemerick/pomegranate/commit/c4e19981c53311e52f5a8060f34b6d3b69d458bd
Upgrade to pomegranate 0.4.0 https://github.com/technomancy/leiningen/commit/ea6288d3a2b054eaf60556696c10366cd050f37e

java.io.FileNotFoundException: Could not locate reply/main__init.class or reply/main.clj on classpath.
--
Error: `clojure.lang.Compiler$CompilerException: java.io.FileNotFoundException: Could not locate reply/main__init.class or reply/main.clj on classpath., compiling:(leiningen/droid/deploy.clj:1:1)`

Move reply to on-demand dependency. https://github.com/technomancy/leiningen/commit/6ede563f07aafe88d7d1020a9a115565a5af8f2c
