### PR TITLE
Handle AAR files that don't include a `res` folder

### DIFF
--- a/src/leiningen/droid/build.clj
+++ b/src/leiningen/droid/build.clj
@@ -218,7 +218,9 @@
         assets (mapcat #(when (.exists (io/file %)) ["-A" (str %)])
                        (concat assets-paths [assets-gen-path]
                                (get-aar-files project "assets")))
-        aar-resources (for [res (get-aar-files project "res")] ["-S" res])
+        aar-resources (for [res (get-aar-files project "res")
+                            :when (.exists ^File res)]
+                        ["-S" res])
         aar-crunched-resources (for [res (get-aar-files project "out-res")
                                      :when (.exists ^File res)]
                                  ["-S" res])

--- a/src/leiningen/droid/code_gen.clj
+++ b/src/leiningen/droid/code_gen.clj
@@ -93,7 +93,9 @@
         android-jar (get-sdk-android-jar sdk-path target-version)
         manifest-file (io/file manifest-path)
         library-specific (if library ["--non-constant-id"] [])
-        aar-resources (for [res (get-aar-files project "res")] ["-S" (str res)])
+        aar-resources (for [res (get-aar-files project "res")
+                            :when (.exists ^File res)]
+                        ["-S" (str res)])
         external-resources (for [res external-res-paths] ["-S" res])]
     (ensure-paths manifest-path res-path android-jar)
     (.mkdirs (io/file gen-path))


### PR DESCRIPTION
This is technically against the AAR spec, but many of Google's own
libraries omit this folder.